### PR TITLE
Fix middleware registration and password reset route

### DIFF
--- a/app/Http/Controllers/StatusesController.php
+++ b/app/Http/Controllers/StatusesController.php
@@ -9,8 +9,9 @@ use Auth;
 
 class StatusesController extends Controller
 {
-    public function __contruct(){
-      $this->middleware('auth');
+    public function __construct()
+    {
+        $this->middleware('auth');
     }
 
     public function store(Request $request){

--- a/app/User.php
+++ b/app/User.php
@@ -43,8 +43,9 @@ class User extends Authenticatable
       return "http://www.gravatar.com/avatar/$hash?s=$size";
     }
 
-    public function sendPasswordResetNotfication($token){
-      $this->notify(new ResetPassword($token));
+    public function sendPasswordResetNotification($token)
+    {
+        $this->notify(new ResetPassword($token));
     }
 
     public function statuses(){

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,7 +25,7 @@ Route::delete('logout','SessionsController@destroy')->name('logout');
 Route::get('signup/confirm/{token}','UsersController@confirmEmail')->name('confirm_email');
 
 Route::get('password/reset','Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
-Route::post('passwrod/email','Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
+Route::post('password/email','Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
 Route::get('password/reset/{token}','Auth\ResetPasswordController@showResetForm')->name('password.reset');
 Route::post('password/reset','Auth\ResetPasswordController@reset')->name('password.update');
 

--- a/tests/Feature/StatusesControllerTest.php
+++ b/tests/Feature/StatusesControllerTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class StatusesControllerTest extends TestCase
+{
+    public function test_guest_cannot_create_status()
+    {
+        $response = $this->post('/statuses', ['content' => 'Test status']);
+
+        $response->assertRedirect('/login');
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure StatusesController's auth middleware runs
- correct password reset notification method name
- fix password/email route typo
- add feature test asserting unauthenticated users are redirected when posting statuses

## Testing
- `composer install` *(fails: requires PHP 7)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6882fd84fa8083228d5059776498af4b