### PR TITLE
Fix sign-up flash message grammar

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -53,7 +53,7 @@ class UsersController extends Controller
       //Auth::login($user);
       $this->sendEmailConfirmationTo($user);
       //session()->flash('success','Welcome,you will have a new trip');
-      session()->flash('success','Confirmation email has sent to you email address!');
+      session()->flash('success','Confirmation email has been sent to your email address!');
       //return redirect()->route('users.show',[$user]);
       return redirect('/');
     }


### PR DESCRIPTION
## Summary
- correct grammar for sign-up confirmation email flash message

## Testing
- `composer install --no-interaction` *(fails: lock file requires PHP 7)*
- `./vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882ff154fdc8322b71cf700905a6e62