### PR TITLE
Add password email route test and fix route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -25,7 +25,7 @@ Route::delete('logout','SessionsController@destroy')->name('logout');
 Route::get('signup/confirm/{token}','UsersController@confirmEmail')->name('confirm_email');
 
 Route::get('password/reset','Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
-Route::post('passwrod/email','Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
+Route::post('password/email','Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
 Route::get('password/reset/{token}','Auth\ResetPasswordController@showResetForm')->name('password.reset');
 Route::post('password/reset','Auth\ResetPasswordController@reset')->name('password.update');
 

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -18,4 +18,16 @@ class ExampleTest extends TestCase
 
         $response->assertStatus(200);
     }
+
+    /**
+     * Ensure password reset email route redirects.
+     *
+     * @return void
+     */
+    public function testPasswordEmailPostRedirects()
+    {
+        $response = $this->post('/password/email', ['email' => 'foo@example.com']);
+
+        $response->assertStatus(302);
+    }
 }


### PR DESCRIPTION
## Summary
- fix typo in password/email route
- verify POST `/password/email` redirects

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6882ff9942c48322b461314c36daea4e