### PR TITLE
Fix forgot password route path

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -25,7 +25,7 @@ Route::delete('logout','SessionsController@destroy')->name('logout');
 Route::get('signup/confirm/{token}','UsersController@confirmEmail')->name('confirm_email');
 
 Route::get('password/reset','Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
-Route::post('passwrod/email','Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
+Route::post('password/email','Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
 Route::get('password/reset/{token}','Auth\ResetPasswordController@showResetForm')->name('password.reset');
 Route::post('password/reset','Auth\ResetPasswordController@reset')->name('password.update');
 


### PR DESCRIPTION
## Summary
- fix a typo in the forgot password email route

## Testing
- `php artisan route:list` *(fails: vendor autoload missing)*
- `composer install` *(fails: PHP version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6882ff995960832295e54e87fa0f5a1b