### PR TITLE
Fix StatusPolicy docblock description

### DIFF
--- a/app/Policies/StatusPolicy.php
+++ b/app/Policies/StatusPolicy.php
@@ -12,9 +12,11 @@ class StatusPolicy
     use HandlesAuthorization;
 
     /**
-     * Create a new policy instance.
+     * Determine whether the given user can delete the status.
      *
-     * @return void
+     * @param  \App\User   $user
+     * @param  \App\Status $status
+     * @return bool
      */
     public function destroy(User $user,Status $status)
     {


### PR DESCRIPTION
## Summary
- update `destroy` docblock in `StatusPolicy` with correct description

## Testing
- `composer install --no-interaction` *(fails: PHP version requirements)*

------
https://chatgpt.com/codex/tasks/task_e_6882ff999fdc8322a85160e8ffb62883