### PR TITLE
Update token generation

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 
 use App\Notifications\ResetPassword;
 use Auth;
+use Illuminate\Support\Str;
 
 class User extends Authenticatable
 {
@@ -34,7 +35,7 @@ class User extends Authenticatable
       parent::boot();
 
       static::creating(function($user){
-        $user->activation_token=str_random(30);
+        $user->activation_token = Str::random(30);
       });
     }
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,6 +1,7 @@
 <?php
 
 use Faker\Generator as Faker;
+use Illuminate\Support\Str;
 
 /*
 |--------------------------------------------------------------------------
@@ -23,7 +24,7 @@ $factory->define(App\User::class, function (Faker $faker) {
         'is_admin'=>false,
         'activated'=>true,
         'password' => $password ?: $password = bcrypt('secret'),
-        'remember_token' => str_random(10),
+        'remember_token' => Str::random(10),
         'created_at' => $date_time,
         'updated_at' => $date_time,
     ];


### PR DESCRIPTION
## Summary
- use `Str::random` for token generation
- adjust factory default token generation

## Testing
- `php vendor/bin/phpunit --verbose` *(fails: Could not open input file)*

------
https://chatgpt.com/codex/tasks/task_e_688303481a1083228f842dde6b17ddb2