### PR TITLE
Fix mail sender config usage

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -93,8 +93,8 @@ class UsersController extends Controller
     protected function sendEmailConfirmationTo($user){
       $view='emails.confirm';
       $data=compact('user');
-      $from='h-zhang@junction.tokyo';
-      $name='Admin';
+      $from=config('mail.from.address');
+      $name=config('mail.from.name');
       $to=$user->email;
       $subject="Thank you for signing!";
 


### PR DESCRIPTION
## Summary
- read sender address and name from configuration when sending confirmation emails

## Testing
- `composer install --no-interaction` *(fails: PHP version mismatch)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883034bf2d883228384bee71c9458da