### PR TITLE
Fix gravatar URL

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -40,7 +40,7 @@ class User extends Authenticatable
 
     public function gravatar($size='100'){
       $hash=md5(strtolower(trim($this->attributes['email'])));
-      return "http://www.gravatar.com/avatar/$hash?s=$size";
+      return "https://secure.gravatar.com/avatar/$hash?s=$size";
     }
 
     public function sendPasswordResetNotification($token)


### PR DESCRIPTION
## Summary
- use HTTPS for Gravatar URLs

## Testing
- `composer install --no-interaction --prefer-dist --ignore-platform-reqs` *(fails: CONNECT tunnel failed)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6883034cba40832286d9ba86da31b2cf