### PR TITLE
Fix typo in DatabaseSeeder

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -18,6 +18,6 @@ class DatabaseSeeder extends Seeder
       $this->call(StatusesTableSeeder::class);
       $this->call(FollowersTableSeeder::class);
 
-      Model::regurad();
+      Model::reguard();
     }
 }


### PR DESCRIPTION
## Summary
- fix a typo that prevented mass assignment from being re-enabled in `DatabaseSeeder`

## Testing
- `composer install` *(fails: PHP version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6883034db1848322b9158a4132f299e2