### PR TITLE
Fix follow/unfollow single ID handling

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -70,16 +70,16 @@ class User extends Authenticatable
       return $this->belongsToMany(User::Class,'followers','follower_id','user_id');
     }
 
-    public function follow($user_ids){
+  public function follow($user_ids){
       if(!is_array($user_ids)){
-        $user_ids=compact('user_ids');
+        $user_ids=[ $user_ids ];
       }
       $this->followings()->sync($user_ids,false);
     }
 
     public function unfollow($user_ids){
       if(!is_array($user_ids)){
-        $user_ids=compact('user_ids');
+        $user_ids=[ $user_ids ];
       }
       $this->followings()->detach($user_ids);
     }


### PR DESCRIPTION
## Summary
- ensure single IDs are passed as array in follow and unfollow methods

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_6883034ef4148322a6865f9719108e71